### PR TITLE
[IMPROVE] Use server settings for SITE_URL

### DIFF
--- a/ContentModerationApp.ts
+++ b/ContentModerationApp.ts
@@ -21,8 +21,9 @@ export class ContentModerationApp extends App implements IPreMessageSentPrevent 
     public async executePreMessageSentPrevent(message: IMessage, read: IRead, http: IHttp, persistence: IPersistence): Promise<boolean> {
         // Grabbing image URLs..
         const serverUrl = await read.getEnvironmentReader().getSettings().getById('Content_Moderation_App');
-        const publicUrl = await read.getEnvironmentReader().getSettings().getById('Rocket Chat host URL');
-        const rcHostUrl: string = publicUrl.value;
+        // const publicUrl = await read.getEnvironmentReader().getSettings().getById('Rocket Chat host URL');
+        // const rcHostUrl: string = publicUrl.value;
+        const rcHostUrl = await read.getEnvironmentReader().getServerSettings().getValueById('SITE_URL');
         const contentModerationAppUrl: string = serverUrl.value;
 
         const imageUrl = (message.attachments || []).map((a) => rcHostUrl + a.imageUrl);
@@ -86,16 +87,6 @@ export class ContentModerationApp extends App implements IPreMessageSentPrevent 
         return false;
       }
       protected async extendConfiguration(configuration: IConfigurationExtend, environmentRead: IEnvironmentRead): Promise<void> {
-        await configuration.settings.provideSetting({
-            id: 'Rocket Chat host URL',
-            type: SettingType.STRING,
-            packageValue: '',
-            required: true,
-            public: false,
-            i18nLabel: 'Rocket Chat host URL',
-            i18nDescription: 'Provide the URL where Rocket Chat is hosted',
-            i18nPlaceholder: 'http://rocket-chat:3000',
-        });
         await configuration.settings.provideSetting({
             id: 'Content_Moderation_App',
             type: SettingType.STRING,

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ docker-compose -f docker-compose-server.yml up -d
 ```
 3. Now, Configure the app settings. Provide the Rocket.Chat Host URL and the Flask app Host URL which can be obtained after the 2nd Step. <br>
 **Configuration Setting:** Administration -> Apps -> Content Moderation.<br>
-'Rocket Chat host URL': <Provide your own Rocket Chat Host Url> &  'Content Moderation App Host URL': <Provide the Flask App Host URL> in Content Moderation App's Setting.<br>
- for example: 'Rocket Chat host URL': http://rocket-chat:3000 &  'Content Moderation App Host URL': http://moderation-api:5000/predict<br>
+ 'Content Moderation App Host URL': <Provide the Flask App Host URL> in Content Moderation App's Setting.<br>
+ for example: 'Content Moderation App Host URL': http://moderation-api:5000/predict<br>
 
 ### Quick start guide for developers
 Prerequisites:


### PR DESCRIPTION
This removes the app internal setting `'Rocket Chat host URL'` and uses the setting from the server `'SITE_URL'`, which is guaranteed to be the most up to date information.

Great work with the app (along with its flask part :joy:) btw!